### PR TITLE
fix: prevent opacity flickering in fadeAtom with fill mode both

### DIFF
--- a/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.ts
@@ -17,6 +17,7 @@ export const blurAtom = ({
   direction,
   duration,
   easing = motionTokens.curveLinear,
+  delay = 0,
   fromRadius = '10px',
 }: BlurAtomParams): AtomMotion => {
   const keyframes = [{ filter: `blur(${fromRadius})` }, { filter: 'blur(0px)' }];
@@ -27,5 +28,6 @@ export const blurAtom = ({
     keyframes,
     duration,
     easing,
+    delay,
   };
 };

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.ts
@@ -1,9 +1,7 @@
-import { AtomMotion, PresenceDirection, motionTokens } from '@fluentui/react-motion';
+import { AtomMotion, motionTokens } from '@fluentui/react-motion';
+import { BaseAtomParams } from '../types';
 
-interface BlurAtomParams {
-  direction: PresenceDirection;
-  duration: number;
-  easing?: string;
+interface BlurAtomParams extends BaseAtomParams {
   fromRadius?: string;
 }
 

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.test.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.test.ts
@@ -1,0 +1,72 @@
+import { fadeAtom } from './fade-atom';
+
+describe('fadeAtom', () => {
+  it('creates proper keyframes for enter and exit directions', () => {
+    const enterAtom = fadeAtom({
+      direction: 'enter',
+      duration: 300,
+    });
+
+    const exitAtom = fadeAtom({
+      direction: 'exit',
+      duration: 300,
+    });
+
+    expect(enterAtom.keyframes).toEqual([{ opacity: 0 }, { opacity: 1 }]);
+    expect(exitAtom.keyframes).toEqual([{ opacity: 1 }, { opacity: 0 }]);
+  });
+
+  it('applies custom opacity values', () => {
+    const atom = fadeAtom({
+      direction: 'enter',
+      duration: 300,
+      fromOpacity: 0.5,
+    });
+
+    expect(atom.keyframes).toEqual([{ opacity: 0.5 }, { opacity: 1 }]);
+  });
+
+  it('allows custom fill mode when explicitly provided', () => {
+    const atom = fadeAtom({
+      direction: 'enter',
+      duration: 300,
+      fill: 'forwards',
+    });
+
+    expect(atom.fill).toBe('forwards');
+  });
+
+  it('has fill mode "both" by default to prevent opacity flickering during delays', () => {
+    const enterAtom = fadeAtom({
+      direction: 'enter',
+      duration: 300,
+      delay: 100,
+    });
+
+    const exitAtom = fadeAtom({
+      direction: 'exit',
+      duration: 300,
+      delay: 50,
+    });
+
+    expect(enterAtom.fill).toBe('both');
+    expect(exitAtom.fill).toBe('both');
+  });
+
+  it('includes all expected properties in the returned atom', () => {
+    const atom = fadeAtom({
+      direction: 'enter',
+      duration: 250,
+      delay: 100,
+      easing: 'ease-out',
+    });
+
+    expect(atom).toMatchObject({
+      keyframes: [{ opacity: 0 }, { opacity: 1 }],
+      duration: 250,
+      easing: 'ease-out',
+      delay: 100,
+      fill: 'both',
+    });
+  });
+});

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.ts
@@ -3,6 +3,7 @@ import { BaseAtomParams } from '../types';
 
 interface FadeAtomParams extends BaseAtomParams {
   fromOpacity?: number;
+  fill?: 'none' | 'forwards' | 'backwards' | 'both';
 }
 
 /**
@@ -10,7 +11,9 @@ interface FadeAtomParams extends BaseAtomParams {
  * @param direction - The functional direction of the motion: 'enter' or 'exit'.
  * @param duration - The duration of the motion in milliseconds.
  * @param easing - The easing curve for the motion. Defaults to `motionTokens.curveLinear`.
- * @param fromValue - The starting opacity value. Defaults to 0.
+ * @param delay - Time (ms) to delay the animation. Defaults to 0.
+ * @param fromOpacity - The starting opacity value. Defaults to 0.
+ * @param fill - Defines how values are applied before and after execution. Defaults to 'both'.
  * @returns A motion atom object with opacity keyframes and the supplied duration and easing.
  */
 export const fadeAtom = ({
@@ -19,6 +22,7 @@ export const fadeAtom = ({
   easing = motionTokens.curveLinear,
   delay = 0,
   fromOpacity = 0,
+  fill = 'both',
 }: FadeAtomParams): AtomMotion => {
   const keyframes = [{ opacity: fromOpacity }, { opacity: 1 }];
   if (direction === 'exit') {
@@ -29,5 +33,6 @@ export const fadeAtom = ({
     duration,
     easing,
     delay,
+    fill,
   };
 };

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.ts
@@ -1,9 +1,7 @@
-import { AtomMotion, PresenceDirection, motionTokens } from '@fluentui/react-motion';
+import { AtomMotion, motionTokens } from '@fluentui/react-motion';
+import { BaseAtomParams } from '../types';
 
-interface FadeAtomParams {
-  direction: PresenceDirection;
-  duration: number;
-  easing?: string;
+interface FadeAtomParams extends BaseAtomParams {
   fromOpacity?: number;
 }
 

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/fade-atom.ts
@@ -17,6 +17,7 @@ export const fadeAtom = ({
   direction,
   duration,
   easing = motionTokens.curveLinear,
+  delay = 0,
   fromOpacity = 0,
 }: FadeAtomParams): AtomMotion => {
   const keyframes = [{ opacity: fromOpacity }, { opacity: 1 }];
@@ -27,5 +28,6 @@ export const fadeAtom = ({
     keyframes,
     duration,
     easing,
+    delay,
   };
 };

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.ts
@@ -28,6 +28,7 @@ export const rotateAtom = ({
   direction,
   duration,
   easing = motionTokens.curveLinear,
+  delay = 0,
   axis = 'y',
   angle = -90,
   exitAngle = -angle,
@@ -45,5 +46,6 @@ export const rotateAtom = ({
     keyframes,
     duration,
     easing,
+    delay,
   };
 };

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.ts
@@ -1,12 +1,10 @@
-import { AtomMotion, PresenceDirection, motionTokens } from '@fluentui/react-motion';
+import { AtomMotion, motionTokens } from '@fluentui/react-motion';
 import type { RotateParams } from '../components/Rotate/rotate-types';
+import { BaseAtomParams } from '../types';
 
 type Axis3D = NonNullable<RotateParams['axis']>;
 
-interface RotateAtomParams {
-  direction: PresenceDirection;
-  duration: number;
-  easing?: string;
+interface RotateAtomParams extends BaseAtomParams {
   axis?: Axis3D;
   angle?: number;
   exitAngle?: number;

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/scale-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/scale-atom.ts
@@ -1,9 +1,7 @@
-import { AtomMotion, PresenceDirection, motionTokens } from '@fluentui/react-motion';
+import { AtomMotion, motionTokens } from '@fluentui/react-motion';
+import { BaseAtomParams } from '../types';
 
-interface ScaleAtomParams {
-  direction: PresenceDirection;
-  duration: number;
-  easing?: string;
+interface ScaleAtomParams extends BaseAtomParams {
   fromScale?: number;
   toScale?: number;
 }

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/scale-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/scale-atom.ts
@@ -19,6 +19,7 @@ export const scaleAtom = ({
   direction,
   duration,
   easing = motionTokens.curveLinear,
+  delay = 0,
   fromScale = 0.9,
   toScale = 1,
 }: ScaleAtomParams): AtomMotion => {
@@ -30,5 +31,6 @@ export const scaleAtom = ({
     keyframes,
     duration,
     easing,
+    delay,
   };
 };

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/slide-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/slide-atom.ts
@@ -19,6 +19,7 @@ export const slideAtom = ({
   direction,
   duration,
   easing = motionTokens.curveLinear,
+  delay = 0,
   fromX = '0px',
   fromY = '20px',
 }: SlideAtomParams): AtomMotion => {
@@ -30,5 +31,6 @@ export const slideAtom = ({
     keyframes,
     duration,
     easing,
+    delay,
   };
 };

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/slide-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/slide-atom.ts
@@ -1,9 +1,7 @@
-import { AtomMotion, PresenceDirection, motionTokens } from '@fluentui/react-motion';
+import { AtomMotion, motionTokens } from '@fluentui/react-motion';
+import { BaseAtomParams } from '../types';
 
-interface SlideAtomParams {
-  direction: PresenceDirection;
-  duration: number;
-  easing?: string;
+interface SlideAtomParams extends BaseAtomParams {
   fromX?: string;
   fromY?: string;
 }

--- a/packages/react-components/react-motion-components-preview/library/src/components/Blur/Blur.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Blur/Blur.ts
@@ -6,35 +6,40 @@ import { BlurParams } from './blur-types';
 /**
  * Define a presence motion for blur in/out
  *
- * @param fromRadius - The radius of pixels to blend into the blur. A length string, defaulting to '10px'.
  * @param duration - Time (ms) for the enter transition (blur-in). Defaults to the `durationSlow` value (300 ms).
  * @param easing - Easing curve for the enter transition (blur-in). Defaults to the `curveDecelerateMin` value.
- * @param exitDuration - Time (ms) for the exit transition (blur-out). Defaults to the enter duration.
+ * @param delay - Time (ms) to delay the enter transition. Defaults to 0.
+ * @param exitDuration - Time (ms) for the exit transition (blur-out). Defaults to the `duration` param for symmetry.
  * @param exitEasing - Easing curve for the exit transition (blur-out). Defaults to the `curveAccelerateMin` value.
+ * @param exitDelay - Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry.
+ * @param fromRadius - The blur radius with units to animate from. Defaults to `'10px'`.
  * @param animateOpacity - Whether to animate the opacity. Defaults to `true`.
  */
 const blurPresenceFn: PresenceMotionFn<BlurParams> = ({
-  fromRadius = '10px',
   duration = motionTokens.durationSlow,
   easing = motionTokens.curveDecelerateMin,
+  delay = 0,
   exitDuration = duration,
   exitEasing = motionTokens.curveAccelerateMin,
+  exitDelay = delay,
+  fromRadius = '10px',
   animateOpacity = true,
 }) => {
-  const enterAtoms = [blurAtom({ direction: 'enter', duration, easing, fromRadius })];
+  const enterAtoms = [blurAtom({ direction: 'enter', duration, easing, delay, fromRadius })];
   const exitAtoms = [
     blurAtom({
       direction: 'exit',
       duration: exitDuration,
       easing: exitEasing,
+      delay: exitDelay,
       fromRadius,
     }),
   ];
 
   // Only add fade atoms if animateOpacity is true.
   if (animateOpacity) {
-    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing }));
-    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing }));
+    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing, delay }));
+    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing, delay: exitDelay }));
   }
 
   return {

--- a/packages/react-components/react-motion-components-preview/library/src/components/Blur/blur-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Blur/blur-types.ts
@@ -1,7 +1,8 @@
-import type { PresenceDuration, PresenceEasing, AnimateOpacity } from '../../types';
+import type { PresenceDuration, PresenceEasing, PresenceDelay, AnimateOpacity } from '../../types';
 
 export type BlurParams = PresenceDuration &
   PresenceEasing &
+  PresenceDelay &
   AnimateOpacity & {
     /** The radius of pixels to blend into the blur. A length string, defaulting to '20px'. */
     fromRadius?: string;

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/collapse-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/collapse-types.ts
@@ -1,9 +1,10 @@
-import type { PresenceDuration, PresenceEasing, AnimateOpacity } from '../../types';
+import type { PresenceDuration, PresenceEasing, PresenceDelay, AnimateOpacity } from '../../types';
 
 export type CollapseOrientation = 'horizontal' | 'vertical';
 
 /** Common properties shared by all collapse components */
 type CollapseBaseParams = PresenceEasing &
+  PresenceDelay &
   AnimateOpacity & {
     /** The orientation of the size animation. Defaults to `'vertical'` to expand/collapse the height. */
     orientation?: CollapseOrientation;

--- a/packages/react-components/react-motion-components-preview/library/src/components/Fade/Fade.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Fade/Fade.ts
@@ -12,18 +12,22 @@ import { FadeParams } from './fade-types';
  *
  * @param duration - Time (ms) for the enter transition (fade-in). Defaults to the `durationNormal` value (200 ms).
  * @param easing - Easing curve for the enter transition (fade-in). Defaults to the `curveEasyEase` value.
+ * @param delay - Time (ms) to delay the enter transition. Defaults to 0.
  * @param exitDuration - Time (ms) for the exit transition (fade-out). Defaults to the `duration` param for symmetry.
  * @param exitEasing - Easing curve for the exit transition (fade-out). Defaults to the `easing` param for symmetry.
+ * @param exitDelay - Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry.
  */
 export const fadePresenceFn: PresenceMotionFn<FadeParams> = ({
   duration = motionTokens.durationNormal,
   easing = motionTokens.curveEasyEase,
+  delay = 0,
   exitDuration = duration,
   exitEasing = easing,
+  exitDelay = delay,
 }) => {
   return {
-    enter: fadeAtom({ direction: 'enter', duration, easing }),
-    exit: fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing }),
+    enter: fadeAtom({ direction: 'enter', duration, easing, delay }),
+    exit: fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing, delay: exitDelay }),
   };
 };
 

--- a/packages/react-components/react-motion-components-preview/library/src/components/Fade/fade-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Fade/fade-types.ts
@@ -1,3 +1,3 @@
-import type { PresenceDuration, PresenceEasing } from '../../types';
+import type { PresenceDuration, PresenceEasing, PresenceDelay } from '../../types';
 
-export type FadeParams = PresenceDuration & PresenceEasing;
+export type FadeParams = PresenceDuration & PresenceEasing & PresenceDelay;

--- a/packages/react-components/react-motion-components-preview/library/src/components/Rotate/Rotate.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Rotate/Rotate.ts
@@ -8,21 +8,25 @@ import { RotateParams } from './rotate-types';
  *
  * @param duration - Time (ms) for the enter transition (rotate-in). Defaults to the `durationGentle` value.
  * @param easing - Easing curve for the enter transition (rotate-in). Defaults to the `curveDecelerateMax` value.
+ * @param delay - Time (ms) to delay the enter transition. Defaults to 0.
  * @param exitDuration - Time (ms) for the exit transition (rotate-out). Defaults to the `duration` param for symmetry.
  * @param exitEasing - Easing curve for the exit transition (rotate-out). Defaults to the `curveAccelerateMax` value.
+ * @param exitDelay - Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry.
  * @param axis - The axis of rotation: 'x', 'y', or 'z'. Defaults to 'y'.
  * @param angle - The starting rotation angle in degrees. Defaults to -90.
  * @param exitAngle - The ending rotation angle in degrees. Defaults to the negation of `angle`.
  * @param animateOpacity - Whether to animate the opacity during the rotation. Defaults to `true`.
  */
 const rotatePresenceFn: PresenceMotionFn<RotateParams> = ({
+  duration = motionTokens.durationGentle,
+  easing = motionTokens.curveDecelerateMax,
+  delay = 0,
+  exitDuration = duration,
+  exitEasing = motionTokens.curveAccelerateMax,
+  exitDelay = delay,
   axis = 'y',
   angle = -90,
   exitAngle = -angle,
-  duration = motionTokens.durationGentle,
-  exitDuration = duration,
-  easing = motionTokens.curveDecelerateMax,
-  exitEasing = motionTokens.curveAccelerateMax,
   animateOpacity = true,
 }: RotateParams) => {
   const enterAtoms: AtomMotion[] = [
@@ -30,6 +34,7 @@ const rotatePresenceFn: PresenceMotionFn<RotateParams> = ({
       direction: 'enter',
       duration,
       easing,
+      delay,
       axis,
       angle,
       exitAngle,
@@ -41,6 +46,7 @@ const rotatePresenceFn: PresenceMotionFn<RotateParams> = ({
       direction: 'exit',
       duration: exitDuration,
       easing: exitEasing,
+      delay: exitDelay,
       axis,
       angle,
       exitAngle,
@@ -48,8 +54,8 @@ const rotatePresenceFn: PresenceMotionFn<RotateParams> = ({
   ];
 
   if (animateOpacity) {
-    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing }));
-    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing }));
+    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing, delay }));
+    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing, delay: exitDelay }));
   }
 
   return {

--- a/packages/react-components/react-motion-components-preview/library/src/components/Rotate/rotate-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Rotate/rotate-types.ts
@@ -1,9 +1,10 @@
-import type { PresenceDuration, PresenceEasing, AnimateOpacity } from '../../types';
+import type { PresenceDuration, PresenceEasing, PresenceDelay, AnimateOpacity } from '../../types';
 
 type Axis3D = 'x' | 'y' | 'z';
 
 export type RotateParams = PresenceDuration &
   PresenceEasing &
+  PresenceDelay &
   AnimateOpacity & {
     /**
      * The axis of rotation: 'x', 'y', or 'z'.

--- a/packages/react-components/react-motion-components-preview/library/src/components/Scale/Scale.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Scale/Scale.ts
@@ -13,33 +13,38 @@ import { ScaleParams } from './scale-types';
  *
  * @param duration - Time (ms) for the enter transition (scale-in). Defaults to the `durationGentle` value (250 ms).
  * @param easing - Easing curve for the enter transition (scale-in). Defaults to the `curveDecelerateMax` value.
+ * @param delay - Time (ms) to delay the enter transition. Defaults to 0.
  * @param exitDuration - Time (ms) for the exit transition (scale-out). Defaults to the `durationNormal` value (200 ms).
  * @param exitEasing - Easing curve for the exit transition (scale-out). Defaults to the `curveAccelerateMax` value.
+ * @param exitDelay - Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry.
  * @param fromScale - The scale value to animate from. Defaults to `0.9`.
  * @param animateOpacity - Whether to animate the opacity. Defaults to `true`.
  */
 const scalePresenceFn: PresenceMotionFn<ScaleParams> = ({
   duration = motionTokens.durationGentle,
   easing = motionTokens.curveDecelerateMax,
+  delay = 0,
   exitDuration = motionTokens.durationNormal,
   exitEasing = motionTokens.curveAccelerateMax,
+  exitDelay = delay,
   fromScale = 0.9,
   animateOpacity = true,
 }) => {
-  const enterAtoms = [scaleAtom({ direction: 'enter', duration, easing, fromScale: fromScale })];
+  const enterAtoms = [scaleAtom({ direction: 'enter', duration, easing, delay, fromScale: fromScale })];
   const exitAtoms = [
     scaleAtom({
       direction: 'exit',
       duration: exitDuration,
       easing: exitEasing,
+      delay: exitDelay,
       fromScale,
     }),
   ];
 
   // Only add fade atoms if animateOpacity is true.
   if (animateOpacity) {
-    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing }));
-    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing }));
+    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing, delay }));
+    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing, delay: exitDelay }));
   }
 
   return {

--- a/packages/react-components/react-motion-components-preview/library/src/components/Scale/scale-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Scale/scale-types.ts
@@ -1,7 +1,8 @@
-import type { PresenceDuration, PresenceEasing, AnimateOpacity } from '../../types';
+import type { PresenceDuration, PresenceEasing, PresenceDelay, AnimateOpacity } from '../../types';
 
 export type ScaleParams = PresenceDuration &
   PresenceEasing &
+  PresenceDelay &
   AnimateOpacity & {
     /** The scale value to animate from. Defaults to `0.9`. */
     fromScale?: number;

--- a/packages/react-components/react-motion-components-preview/library/src/components/Slide/Slide.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Slide/Slide.ts
@@ -13,8 +13,10 @@ import { SlideParams } from './slide-types';
  *
  * @param duration - Time (ms) for the enter transition (slide-in). Defaults to the `durationNormal` value (200 ms).
  * @param easing - Easing curve for the enter transition (slide-in). Defaults to the `curveDecelerateMid` value.
+ * @param delay - Time (ms) to delay the enter transition. Defaults to 0.
  * @param exitDuration - Time (ms) for the exit transition (slide-out). Defaults to the `duration` param for symmetry.
  * @param exitEasing - Easing curve for the exit transition (slide-out). Defaults to the `curveAccelerateMid` value.
+ * @param exitDelay - Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry.
  * @param fromX - The X translate value with units to animate from. Defaults to `'0px'`.
  * @param fromY - The Y translate value with units to animate from. Defaults to `'20px'`.
  * @param animateOpacity - Whether to animate the opacity. Defaults to `true`.
@@ -22,18 +24,21 @@ import { SlideParams } from './slide-types';
 const slidePresenceFn: PresenceMotionFn<SlideParams> = ({
   duration = motionTokens.durationNormal,
   easing = motionTokens.curveDecelerateMid,
+  delay = 0,
   exitDuration = duration,
   exitEasing = motionTokens.curveAccelerateMid,
+  exitDelay = delay,
   fromX = '0px',
   fromY = '20px',
   animateOpacity = true,
 }: SlideParams) => {
-  const enterAtoms = [slideAtom({ direction: 'enter', duration, easing, fromX, fromY })];
+  const enterAtoms = [slideAtom({ direction: 'enter', duration, easing, delay, fromX, fromY })];
   const exitAtoms = [
     slideAtom({
       direction: 'exit',
       duration: exitDuration,
       easing: exitEasing,
+      delay: exitDelay,
       fromX,
       fromY,
     }),
@@ -41,8 +46,8 @@ const slidePresenceFn: PresenceMotionFn<SlideParams> = ({
 
   // Only add fade atoms if animateOpacity is true.
   if (animateOpacity) {
-    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing }));
-    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing }));
+    enterAtoms.push(fadeAtom({ direction: 'enter', duration, easing, delay }));
+    exitAtoms.push(fadeAtom({ direction: 'exit', duration: exitDuration, easing: exitEasing, delay: exitDelay }));
   }
 
   return {

--- a/packages/react-components/react-motion-components-preview/library/src/components/Slide/slide-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Slide/slide-types.ts
@@ -1,7 +1,8 @@
-import type { PresenceDuration, PresenceEasing, AnimateOpacity } from '../../types';
+import type { PresenceDuration, PresenceEasing, PresenceDelay, AnimateOpacity } from '../../types';
 
 export type SlideParams = PresenceDuration &
   PresenceEasing &
+  PresenceDelay &
   AnimateOpacity & {
     /** The X translate value with units to animate from. Defaults to `'0px'`. */
     fromX?: string;

--- a/packages/react-components/react-motion-components-preview/library/src/testing/testUtils.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/testing/testUtils.ts
@@ -26,11 +26,13 @@ export function expectPresenceMotionObject(component: PresenceComponent) {
     enter: expect.objectContaining({
       duration: expect.any(Number),
       easing: expect.any(String),
+      delay: expect.any(Number),
       keyframes: expect.any(Array),
     }),
     exit: expect.objectContaining({
       duration: expect.any(Number),
       easing: expect.any(String),
+      delay: expect.any(Number),
       keyframes: expect.any(Array),
     }),
   });
@@ -42,18 +44,20 @@ export function expectPresenceMotionArray(component: PresenceComponent) {
   // eslint-disable-next-line @nx/workspace-no-restricted-globals
   expect(presenceMotionFn?.({ element: document.createElement('div') })).toMatchObject({
     enter: expect.arrayContaining([
-      {
+      expect.objectContaining({
         duration: expect.any(Number),
         easing: expect.any(String),
+        delay: expect.any(Number),
         keyframes: expect.any(Array),
-      },
+      }),
     ]),
     exit: expect.arrayContaining([
-      {
+      expect.objectContaining({
         duration: expect.any(Number),
         easing: expect.any(String),
+        delay: expect.any(Number),
         keyframes: expect.any(Array),
-      },
+      }),
     ]),
   });
 }

--- a/packages/react-components/react-motion-components-preview/library/src/types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/types.ts
@@ -51,6 +51,17 @@ export type PresenceEasing = {
 };
 
 /**
+ * Common delay parameters for presence motion components.
+ */
+export type PresenceDelay = {
+  /** Time (ms) to delay the enter transition. */
+  delay?: number;
+
+  /** Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry. */
+  exitDelay?: number;
+};
+
+/**
  * Common opacity animation parameter for motion components.
  */
 export type AnimateOpacity = {
@@ -59,7 +70,7 @@ export type AnimateOpacity = {
 };
 
 /**
- * Common parameters shared by all atom functions (without delay).
+ * Common parameters shared by all atom functions.
  */
 export type BaseAtomParams = {
   /** The functional direction of the motion: 'enter' or 'exit'. */
@@ -68,4 +79,6 @@ export type BaseAtomParams = {
   duration: number;
   /** The easing curve for the motion. */
   easing?: string;
+  /** Time (ms) to delay the animation. */
+  delay?: number;
 };

--- a/packages/react-components/react-motion-components-preview/library/src/types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/types.ts
@@ -1,4 +1,4 @@
-import type { MotionParam, PresenceMotion, PresenceMotionFn } from '@fluentui/react-motion';
+import type { MotionParam, PresenceMotion, PresenceMotionFn, PresenceDirection } from '@fluentui/react-motion';
 
 /**
  * This is a factory function that generates a motion object from variant params, e.g. duration, easing, etc.
@@ -56,4 +56,16 @@ export type PresenceEasing = {
 export type AnimateOpacity = {
   /** Whether to animate the opacity. Defaults to `true`. */
   animateOpacity?: boolean;
+};
+
+/**
+ * Common parameters shared by all atom functions (without delay).
+ */
+export type BaseAtomParams = {
+  /** The functional direction of the motion: 'enter' or 'exit'. */
+  direction: PresenceDirection;
+  /** The duration of the motion in milliseconds. */
+  duration: number;
+  /** The easing curve for the motion. */
+  easing?: string;
 };


### PR DESCRIPTION
## Summary
This PR implements the solution for opacity flickering that occurs when using the fadeAtom with delays.

## Key Changes
- Add fill parameter to fadeAtom with default value of both to prevent opacity flickering
- Comprehensive test coverage with new test file fade-atom.test.ts covering all functionality
- Maintain backwards compatibility with optional fill parameter

## Problem Solved
When using fadeAtom with delays, there was visual flickering where the element would briefly show its original opacity before the animation started. The fill both mode ensures that during the delay period and after completion, the element maintains proper opacity values.

## Testing
- All existing tests continue to pass (32/32)
- New comprehensive test suite for fadeAtom functionality
- Tests verify default fill mode behavior and custom fill mode override capability

This is PR 3 of 4 in the motion system improvements series.